### PR TITLE
Fix deallocation handling when changing parent

### DIFF
--- a/ADCoordinator/Classes/Coordinator.swift
+++ b/ADCoordinator/Classes/Coordinator.swift
@@ -23,7 +23,13 @@ open class Coordinator {
     /**
      * Stores a weak reference to the parent coordinator.
      */
-    public private(set) weak var parent: Coordinator?
+    public private(set) weak var parent: Coordinator? {
+        didSet {
+            guard let nativeNavigator = boundNativeNavigator else { return }
+            nativeNavigator.removeCallbackForDealloc()
+            parent?.removeChild(self, onDeallocationOf: nativeNavigator)
+        }
+    }
 
     /**
     * Stores the current object observed for deallocation

--- a/ADCoordinator/Classes/NativeNavigator.swift
+++ b/ADCoordinator/Classes/NativeNavigator.swift
@@ -23,7 +23,7 @@ extension NativeNavigator where Self: NSObject {
             ) as? DeallocObserver
         }
         set {
-            guard deallocObserver == nil else {
+            guard deallocObserver == nil || newValue == nil else {
                 preconditionFailure("DeallocObserver is already set")
             }
             objc_setAssociatedObject(
@@ -48,5 +48,6 @@ extension NativeNavigator where Self: NSObject {
     */
     func removeCallbackForDealloc() {
         deallocObserver?.invalidate()
+        deallocObserver = nil
     }
 }

--- a/Example/Tests/CoordinatorTests.swift
+++ b/Example/Tests/CoordinatorTests.swift
@@ -102,4 +102,28 @@ class CoordinatorTests: XCTestCase {
         // Then
         XCTAssertEqual(parent.children, [child])
     }
+
+    func testBindToLifecycleWithParentChange() {
+        // Given
+        let parent1 = ParentCoordinator()
+        let parent2 = ParentCoordinator()
+        let child = ChildCoordinator()
+        parent1.addChild(child)
+
+        autoreleasepool {
+            var viewController = UIViewController()
+
+            child.bindToLifecycle(of: viewController)
+
+            // When
+            parent1.removeChild(child)
+            parent2.addChild(child)
+
+            viewController = UIViewController() // dealloc previous instance
+        }
+
+        // Then
+        XCTAssertTrue(parent1.children.isEmpty)
+        XCTAssertTrue(parent2.children.isEmpty)
+    }
 }


### PR DESCRIPTION
Description of the issue:
When changing the parent of a coordinator which is binded to a NativeNavigatiorObject, on the deallocation of this object a wrong call is made to `removeChild(_:)` on the old parent and not on new one. Thus causing an assertion to be raised as it no longer is a child of the old parent.

I need this fix for the use case of a restoration from a PictureInPicture player